### PR TITLE
Fix typos

### DIFF
--- a/2013-14/1-premierleague-ii.txt
+++ b/2013-14/1-premierleague-ii.txt
@@ -90,7 +90,7 @@ Matchday 25
   Liverpool FC          5-1  Arsenal FC  
   Aston Villa           0-2  West Ham United  
   Chelsea FC            3-0  Newcastle United  
-  Crystal Palac         3-1  West Bromwich Albion  
+  Crystal Palace        3-1  West Bromwich Albion  
   Norwich City          0-0  Manchester City  
   Southampton FC        2-2  Stoke City  
   Sunderland AFC        0-2  Hull City  


### PR DESCRIPTION
After closer investigation, openfootball/football.json#3 seems to be caused by typos in the source data