### PR TITLE
Corrections

### DIFF
--- a/2016-17/1-premierleague-i.txt
+++ b/2016-17/1-premierleague-i.txt
@@ -110,7 +110,7 @@ Matchday 5
 
 [Fri Sept/16]
   Chelsea FC              1-2 (0-2)  Liverpool FC  @ Stamford Bridge, London
-    [Diego Costa 61'; Lovren '17  J. Henderson '36]                   
+    [Diego Costa 61'; Lovren '17  J. Henderson '36]
 [Sat Sept/17]
   Hull City               1-4 (0-1)  Arsenal FC           @ Kingston Communications Stadium, Hull
     [Snodgrass '79 (pen.); A. Sanchez 17', 83' Walcott 55' Xhaka 90+2']
@@ -302,8 +302,8 @@ Matchday 16
 [Tue Dec/13]
   AFC Bournemouth       1-0  Leicester City
   Everton FC            2-1  Arsenal FC
-  
- [Wed Dec/14] 
+
+ [Wed Dec/14]
   Crystal Palace        1-2  Manchester United
   Middlesbrough FC      0-3  Liverpool FC
   Sunderland AFC        0-1  Chelsea FC
@@ -313,8 +313,8 @@ Matchday 16
   Stoke City            0-0  Southampton FC
   Tottenham Hotspur     3-0  Hull City
 
- 
- 
+
+
 Matchday 17
 
 [Sat Dec/17]
@@ -335,7 +335,7 @@ Matchday 18
   Arsenal FC            1-0  West Bromwich Albion
   Burnley FC            1-0  Middlesbrough FC
   Chelsea FC            3-0  AFC Bournemouth
-  Hull City             0-2  Manchester City
+  Hull City             0-3  Manchester City
   Leicester City        0-2  Everton FC
   Liverpool FC          4-1  Stoke City
   Manchester United     3-1  Sunderland AFC
@@ -353,6 +353,6 @@ Matchday 19
   Leicester City        1-0  West Ham United
   Liverpool FC          1-0  Manchester City
   Manchester United     2-1  Middlesbrough FC
-  Southampton FC        0-3  West Bromwich Albion
+  Southampton FC        1-2  West Bromwich Albion
   Swansea City          0-3  AFC Bournemouth
   Watford FC            1-4  Tottenham Hotspur

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -260,15 +260,15 @@ Matchday 35
 Matchday 36
 
 [Sat May/6]
-  AFC Bournemouth  Stoke City
+  AFC Bournemouth 2-2 Stoke City
   Arsenal FC  Manchester United
-  Burnley FC  West Bromwich Albion
+  Burnley FC 2-2 West Bromwich Albion
   Chelsea FC  Middlesbrough FC
-  Hull City  Sunderland AFC
-  Leicester City  Watford FC
+  Hull City 0-2 Sunderland AFC
+  Leicester City 3-0 Watford FC
   Liverpool FC  Southampton FC
-  Manchester City  Crystal Palace
-  Swansea City  Everton FC
+  Manchester City 5-0 Crystal Palace
+  Swansea City 1-0 Everton FC
   West Ham United 1-0 Tottenham Hotspur
 
 Postponed Matchday 26

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -263,7 +263,7 @@ Matchday 36
   AFC Bournemouth 2-2 Stoke City
   Arsenal FC 2-0 Manchester United
   Burnley FC 2-2 West Bromwich Albion
-  Chelsea FC  Middlesbrough FC
+  Chelsea FC 3-0 Middlesbrough FC
   Hull City 0-2 Sunderland AFC
   Leicester City 3-0 Watford FC
   Liverpool FC 0-0 Southampton FC
@@ -273,7 +273,7 @@ Matchday 36
 
 Postponed Matchday 26
 [Wed May/10]
-  Southampton FC   Arsenal FC
+  Southampton FC 0-2 Arsenal FC
 
 Matchday 37
 

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -282,7 +282,7 @@ Matchday 37
   Crystal Palace 4-0 Hull City
   Everton FC 1-0 Watford FC
   Manchester City 2-1 Leicester City
-  Middlesbrough FC  Southampton FC
+  Middlesbrough FC 1-2 Southampton FC
   Stoke City 1-4 Arsenal FC
   Sunderland AFC 0-2 Swansea City
   Tottenham Hotspur 2-1 Manchester United
@@ -291,12 +291,12 @@ Matchday 37
 
 Postponed Matchday 28
 [Mon May/15]
-  Chelsea FC   Watford FC
+  Chelsea FC 4-3 Watford FC
 
 Postponed Matchday 34
 [Tue May/16]
-  Arsenal FC  Sunderland AFC
-  Manchester City  West Bromwich Albion
+  Arsenal FC 2-0 Sunderland AFC
+  Manchester City 3-1 West Bromwich Albion
 
 Postponed Matchday 28
 [Wed May/17]

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -287,7 +287,7 @@ Matchday 37
   Sunderland AFC 0-2 Swansea City
   Tottenham Hotspur  Manchester United
   West Bromwich Albion 0-1 Chelsea FC
-  West Ham United  Liverpool FC
+  West Ham United 0-4 Liverpool FC
 
 Postponed Matchday 28
 [Mon May/15]

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -278,15 +278,15 @@ Postponed Matchday 26
 Matchday 37
 
 [Sat May/13]
-  AFC Bournemouth  Burnley FC
-  Crystal Palace  Hull City
-  Everton FC  Watford FC
-  Manchester City  Leicester City
+  AFC Bournemouth 2-1 Burnley FC
+  Crystal Palace 4-0 Hull City
+  Everton FC 1-0 Watford FC
+  Manchester City 2-1 Leicester City
   Middlesbrough FC  Southampton FC
-  Stoke City  Arsenal FC
-  Sunderland AFC  Swansea City
+  Stoke City 1-4 Arsenal FC
+  Sunderland AFC 0-2 Swansea City
   Tottenham Hotspur  Manchester United
-  West Bromwich Albion  Chelsea FC
+  West Bromwich Albion 0-1 Chelsea FC
   West Ham United  Liverpool FC
 
 Postponed Matchday 28

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -285,7 +285,7 @@ Matchday 37
   Middlesbrough FC  Southampton FC
   Stoke City 1-4 Arsenal FC
   Sunderland AFC 0-2 Swansea City
-  Tottenham Hotspur  Manchester United
+  Tottenham Hotspur 2-1 Manchester United
   West Bromwich Albion 0-1 Chelsea FC
   West Ham United 0-4 Liverpool FC
 

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -261,12 +261,12 @@ Matchday 36
 
 [Sat May/6]
   AFC Bournemouth 2-2 Stoke City
-  Arsenal FC  Manchester United
+  Arsenal FC 2-0 Manchester United
   Burnley FC 2-2 West Bromwich Albion
   Chelsea FC  Middlesbrough FC
   Hull City 0-2 Sunderland AFC
   Leicester City 3-0 Watford FC
-  Liverpool FC  Southampton FC
+  Liverpool FC 0-0 Southampton FC
   Manchester City 5-0 Crystal Palace
   Swansea City 1-0 Everton FC
   West Ham United 1-0 Tottenham Hotspur

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -300,7 +300,7 @@ Postponed Matchday 34
 
 Postponed Matchday 28
 [Wed May/17]
-  Southampton FC  Manchester United
+  Southampton FC 0-0 Manchester United
 
 
 Postponed Matchday 34

--- a/2016-17/1-premierleague-ii.txt
+++ b/2016-17/1-premierleague-ii.txt
@@ -80,7 +80,7 @@ Matchday 25
   Manchester United     2-0  Watford FC
   Middlesbrough FC      0-0  Everton FC
   Stoke City            1-0  Crystal Palace
-  Sunderland AFC        0-2  Southampton FC
+  Sunderland AFC        0-4  Southampton FC
   Swansea City          2-0  Leicester City
   West Ham United       2-2  West Bromwich Albion
 
@@ -92,7 +92,7 @@ Matchday 26
   Everton FC            2-0  Sunderland AFC
   Hull City             1-1  Burnley FC
   Leicester City        3-1  Liverpool FC
-  Manchester City       0-0  Manchester United         
+  Manchester City       0-0  Manchester United
   Southampton FC  Arsenal FC                 postponed to Wed 10.5.
   Tottenham Hotspur     4-0  Stoke City
   Watford FC            1-1  West Ham United
@@ -116,15 +116,15 @@ Matchday 28
 
 [Sat Mar/11]
   AFC Bournemouth       3-2  West Ham United
-  Arsenal FC            1-0  Leicester City                
+  Arsenal FC            1-0  Leicester City
   Liverpool FC          2-1 Burnley FC
   Chelsea FC  Watford FC                    postponed to Mon 15.5.
   Everton FC            3-0  West Bromwich Albion
   Hull City             2-1  Swansea City
-  Manchester City       0-0  Stoke City               
-  Middlesbrough FC      1-0  Sunderland AFC          
+  Manchester City       0-0  Stoke City
+  Middlesbrough FC      1-0  Sunderland AFC
   Southampton FC  Manchester United         postponed to Wed 17.5.
-  Crystal Palace        0-1  Tottenham Hotspur         
+  Crystal Palace        0-1  Tottenham Hotspur
 
 Matchday 29
 
@@ -133,7 +133,7 @@ Matchday 29
   Crystal Palace        1-0  Watford FC
   Everton FC            4-0  Hull City
   Manchester City       1-1  Liverpool FC
-  Middlesbrough FC      1-3  Manchester United        
+  Middlesbrough FC      1-3  Manchester United
   Stoke City            1-2  Chelsea FC
   Sunderland AFC        0-0  Burnley FC
   Tottenham Hotspur     2-1  Southampton FC
@@ -196,44 +196,44 @@ Matchday 33
   Tottenham Hotspur     4-0  AFC Bournemouth
   Watford FC            1-0  Swansea City
   West Bromwich Albion  0-1  Liverpool FC
-  
+
  1. Aufsteiger to Premier League 2017/18
-  Brighton & Hove Albion 
- 
+  Brighton & Hove Albion
+
 Matchday 34
 
 [Sat Apr/22]
   AFC Bournemouth        4-0  Middlesbrough FC
   Arsenal FC  Sunderland AFC               postponed to Tue 16.5.
-  Burnley FC             0-2  Manchester United 
-  Chelsea FC             4-2  Southampton FC              
+  Burnley FC             0-2  Manchester United
+  Chelsea FC             4-2  Southampton FC
   Hull City              2-0  Watford FC
-  Leicester City  Tottenham Hotspur        postponed to Thu 18.5. 
+  Leicester City  Tottenham Hotspur        postponed to Thu 18.5.
   Liverpool FC           1-2  Crystal Palace
   Manchester City  West Bromwich Albion    postponed to Tue 16.5.
   Swansea City           2-0  Stoke City
   West Ham United        0-0  Everton FC
-  
+
  2. Aufsteiger to Premier League 2017/18
-  Newcastle United 
-  
+  Newcastle United
+
 Postponed Mathchday 34
 
 [Tue Apr/25]
-  Chelsesa FC            4-2 Southampton FC
-  
+  Chelsea FC             4-2 Southampton FC
+
 Postponed Matchday 28
-  
+
 [Wed Apr/26]
   Arsenal FC             1-0 Leicester City
   Middlesbrough FC       1-0 Sunderland AFC
   Crystal Palace         0-1 Tottenham Hotspur
-  
+
 Postponed Matchday 26
-  
+
 (Thu Apr/27)
   Manchester City        0-0 Manchester United
-  
+
 Matchday 35
 
 [Sat Apr/29]
@@ -247,14 +247,14 @@ Matchday 35
   Tottenham Hotspur      2-0  Arsenal FC
   Watford FC             0-1  Liverpool FC
   West Bromwich Albion   0-1  Leicester City
-  
+
  1. Absteiger Premier League 2016/17
   Sunderland AFC
-  
+
  Playoff um 3. Premier League Aufsteiger 2017/18
    Reading FC - Fulham FC
    Sheffield Wednesday - Huddersfield Town
-   
+
    Reading FC/Fulham FC - Sheffield Wednesday/Huddersfield Town
 
 Matchday 36
@@ -269,12 +269,12 @@ Matchday 36
   Liverpool FC  Southampton FC
   Manchester City  Crystal Palace
   Swansea City  Everton FC
-  West Ham United  Tottenham Hotspur
-  
+  West Ham United 1-0 Tottenham Hotspur
+
 Postponed Matchday 26
 [Wed May/10]
   Southampton FC   Arsenal FC
- 
+
 Matchday 37
 
 [Sat May/13]
@@ -288,25 +288,25 @@ Matchday 37
   Tottenham Hotspur  Manchester United
   West Bromwich Albion  Chelsea FC
   West Ham United  Liverpool FC
-  
+
 Postponed Matchday 28
 [Mon May/15]
   Chelsea FC   Watford FC
- 
+
 Postponed Matchday 34
 [Tue May/16]
   Arsenal FC  Sunderland AFC
-  Manchester City  West Bromwich Albion 
-    
-Postponed Matchday 28  
+  Manchester City  West Bromwich Albion
+
+Postponed Matchday 28
 [Wed May/17]
-  Southampton FC  Manchester United 
-  
- 
-Postponed Matchday 34   
+  Southampton FC  Manchester United
+
+
+Postponed Matchday 34
 [Thu May/18]
   Leicester City  Tottenham Hotspur
-    
+
 
 Matchday 38
 


### PR DESCRIPTION
I have been checking this data (and adding results) and compiling league tables and have
discovered some mistakes in the original data. The league tables compiled from my branch agrees with those published by Google and the Premier League.

I think these are all of the corrections I have found (you can check below).

`2016-17/1-premierleague-i.txt`:
```
Hull City             0-3  Manchester City
Southampton FC        1-2  West Bromwich Albion
```

`2016-17/1-premierleague-ii.txt`:
```
Sunderland AFC        0-4  Southampton FC
Chelsea FC            4-2  Southampton FC
```
(The Chelsea-Saints correction is just a correction of the spelling of `Chelsea`.)

My editor automatically removes any trailing spaces from each line so the patch isn't very clear &mdash; you will probably want to check that I have picked out all of the corrections, manually correct the master and dismiss this PR.